### PR TITLE
Update MetricGraph

### DIFF
--- a/philosofool/data_science/graph.py
+++ b/philosofool/data_science/graph.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Hashable, Iterable, Mapping, Callable
 from graphlib import TopologicalSorter
-from typing import Any
+from typing import Any, Optional
 
 import numpy as np  # noqa: F401
 import pandas as pd
@@ -62,12 +62,17 @@ class MetricGraph:
     @classmethod
     def from_model(cls, model: Mapping[Any, tuple[Callable, tuple[Hashable, ...]]]) -> 'MetricGraph':
         """Construct an instance from a mapping of keys to the metric function and dependency names."""
+        metric_functions, dependency_graph = cls.model_to_graph_and_functions(model)
+        return cls(dependency_graph, metric_functions)
+
+    @classmethod
+    def model_to_graph_and_functions(cls, model:  Mapping[Any, tuple[Callable, tuple[Hashable, ...]]]) -> tuple[dict[Any, Callable], dict[Any, tuple[Hashable, ...]]]:
         metric_functions = {}
         dependency_graph = {}
         for key, (fn, deps) in model.items():
             metric_functions[key] = fn
             dependency_graph[key] = deps
-        return cls(dependency_graph, metric_functions)
+        return metric_functions, dependency_graph
 
     def _calculate_metric(self, metric: Hashable, calculated_metrics: Mapping[Any, ArrayLike]) -> ArrayLike:
         """Calculate metric."""

--- a/philosofool/data_science/graph.py
+++ b/philosofool/data_science/graph.py
@@ -90,6 +90,11 @@ class MetricGraph:
                     calculated_metrics[metric] = value
         return {metric: calculated_metrics[metric] for metric in metrics}
 
+    @property
+    def metrics(self) -> tuple:
+        """Return the metrics in the graph, which are topologically sorted."""
+        return tuple(self._topologically_sorted_metrics())
+
     def add_metrics(self, df: pd.DataFrame, metrics: Iterable[Hashable]) -> pd.DataFrame:
         """Add the metrics to a dataframe."""
         calculated_metrics = self.calculate_metrics(df, metrics)

--- a/philosofool/data_science/graph.py
+++ b/philosofool/data_science/graph.py
@@ -99,6 +99,9 @@ class MetricGraph:
                 case value:
                     calculated_metrics[metric] = value
         return {metric: calculated_metrics[metric] for metric in metrics}
+
+    def recalculate_metrics(self, df: pd.DataFrame, metrics: Iterable[Hashable]) -> Mapping[Any, ArrayLike]:
+        """Recalculate the metrics from dataframe."""
         sorted_metrics_and_dependencies = self._sort_metrics_topologically(
             self.get_metric_dependencies(metrics).union(metrics)
         )

--- a/philosofool/data_science/graph.py
+++ b/philosofool/data_science/graph.py
@@ -76,6 +76,11 @@ class MetricGraph:
         data = [calculated_metrics[metric] for metric in dependencies]
         return calculator(*data)
 
+    def model(self, metrics: Optional[Iterable] = None) -> dict:
+        if metrics is None:
+            metrics = list(self.dependency_graph)
+        return {metric: (self.metric_functions[metric], self.dependency_graph[metric]) for metric in metrics}
+
     def calculate_metrics(self, df: pd.DataFrame, metrics: Iterable[Hashable]) -> Mapping[Any, ArrayLike]:
         """Calculate the metrics from dataframe."""
         sorted_metrics_and_dependencies = self._sort_metrics_topologically(

--- a/philosofool/tests/test_data_science.py
+++ b/philosofool/tests/test_data_science.py
@@ -22,6 +22,7 @@ def test_MetricGraph():
     metric_dependencies = {
         'BA': ('H', 'AB'),  # batting average: hits, at bats
         'AB': ('PA', 'BB'),  # At bats: (Plate appearances, base on balls (walks))
+        'H': ('1B', '2B', '3B', 'HR')  # Hits exists in calcs below.
     }
     metric_functions = {
         'BA': np.divide,
@@ -35,6 +36,7 @@ def test_MetricGraph():
     })
     metric_graph = MetricGraph(metric_dependencies, metric_functions)
     result = metric_graph.calculate_metrics(data, ['BA'])
+    assert 'AB' not in result
     assert np.allclose(result['BA'], np.divide([170, 150], [600 - 80, 600 - 100])), f"got {result}"
     result_add = metric_graph.add_metrics(data, ['BA','AB'])
     assert all(k in result_add for k in ['BA', 'AB'])


### PR DESCRIPTION
- prevent recalculation of existing dependencies by `calculate_metrics`.
- introduce `recalculate_metrics` to force recalculation of dependencies. (Useful following group by, for example.)